### PR TITLE
[MINOR] DEV-2199: Add option to change timezone for other components

### DIFF
--- a/mediaire_toolbox/transaction_db/model.py
+++ b/mediaire_toolbox/transaction_db/model.py
@@ -1,7 +1,8 @@
 import datetime
 
-from sqlalchemy import Column, Integer, String, Sequence, DateTime, Date, Enum, \
-    ForeignKey
+from sqlalchemy import (
+    Column, Integer, String, Sequence, DateTime, Date, Enum, ForeignKey
+)
 from sqlalchemy.ext.declarative import declarative_base
 from passlib.apps import custom_app_context as pwd_context
 
@@ -108,7 +109,7 @@ class Transaction(Base):
         return (
             dt.strftime("%Y-%m-%d %H:%M:%S") if dt else None
         )
-        
+
     @staticmethod
     def _str_to_datetime(str_):
         return (
@@ -195,8 +196,12 @@ class Transaction(Base):
         return self
 
     def __repr__(self):
-        return "<Transaction(transaction_id='%s', patient_id='%s', start_date='%s')>" % (
-            self.transaction_id, self.patient_id, self.start_date)
+        return ("<Transaction("
+                "transaction_id='{}',"
+                " patient_id='{}',"
+                " start_date='{}')>".format(self.transaction_id,
+                                            self.patient_id,
+                                            self.start_date))
 
 
 class StudiesMetadata(Base):
@@ -254,7 +259,7 @@ class User(Base):
 
 class UserTransaction(Base):
 
-    """for multi-tenant pipelines, transactions might be associated with users"""
+    """for multi-tenant pipelines, transactions might be associated w/ users"""
     __tablename__ = 'users_transactions'
 
     user_id = Column(Integer, ForeignKey('users.id'),

--- a/mediaire_toolbox/transaction_db/model.py
+++ b/mediaire_toolbox/transaction_db/model.py
@@ -290,10 +290,6 @@ class UserTransaction(Base):
     transaction_id = Column(Integer, ForeignKey('transactions.transaction_id'),
                             primary_key=True)
 
-    @validates()
-    def validate_utc(self, key, datetime_obj):
-        return validate_utc(key, datetime_obj)
-
     def to_dict(self):
         return {'user_id': self.user_id,
                 'transaction_id': self.transaction_id}
@@ -315,10 +311,6 @@ class UserRole(Base):
     role_id = Column(String(64), ForeignKey('roles.role_id'),
                      primary_key=True)
 
-    @validates()
-    def validate_utc(self, key, datetime_obj):
-        return validate_utc(key, datetime_obj)
-
     def to_dict(self):
         return {'user_id': self.user_id,
                 'role_id': self.role_id}
@@ -338,10 +330,6 @@ class UserPreferences(Base):
     user_id = Column(Integer, ForeignKey('users.id'),
                      primary_key=True)
     report_language = Column(String(255))
-
-    @validates()
-    def validate_utc(self, key, datetime_obj):
-        return validate_utc(key, datetime_obj)
 
     def to_dict(self):
         return {'user_id': self.user_id,
@@ -366,10 +354,6 @@ class Role(Base):
     # encoded permissions for this role, 1 bit for each
     permissions = Column(Integer)
 
-    @validates()
-    def validate_utc(self, key, datetime_obj):
-        return validate_utc(key, datetime_obj)
-
     def to_dict(self):
         return {'role_id': self.user_id}
 
@@ -386,10 +370,6 @@ class SchemaVersion(Base):
                     default=constants.TRANSACTIONS_DB_SCHEMA_NAME)
     schema_version = Column(Integer,
                             default=constants.TRANSACTIONS_DB_SCHEMA_VERSION)
-
-    @validates()
-    def validate_utc(self, key, datetime_obj):
-        return validate_utc(key, datetime_obj)
 
 
 def create_all(engine):

--- a/tests/temp_db_base.py
+++ b/tests/temp_db_base.py
@@ -7,18 +7,21 @@ from sqlalchemy import create_engine
 
 class TempDBFactory():
     """Helper to create independent databases for each test"""
-    
+
     def __init__(self, test_suite_name):
         self.test_suite_name = test_suite_name
         self.test_index = 0
-    
+        self.temp_folder = None
+
     def get_temp_db(self):
-        self.temp_folder = tempfile.mkdtemp(suffix='_{}_'.format(self.test_suite_name))
+        self.temp_folder = \
+            tempfile.mkdtemp(suffix='_{}_'.format(self.test_suite_name))
         self.test_index += 1
-        return create_engine('sqlite:///' + 
-                             os.path.join(self.temp_folder,
-                                          't' + str(self.test_index) + '.db') + 
-                             '?check_same_thread=False')
+        return create_engine(
+            'sqlite:///{}?check_same_thread=False'
+            .format(os.path.join(self.temp_folder,
+                                 't{}.db'.format(self.test_index)))
+        )
 
     def delete_temp_folder(self):
         if self.temp_folder:


### PR DESCRIPTION
All `datetime`-type TransactionDB columns are validated to be in UTC timezone.