### PR TITLE
[PATCH] QUICKFIX: Fix docker stage name regex in build_image_from_cache.sh

### DIFF
--- a/scripts/build_image_from_cache.sh
+++ b/scripts/build_image_from_cache.sh
@@ -17,11 +17,7 @@ IMAGE_BASE_NAME=${REGISTRY}/development/mdbrain/${PROJECT_NAME}
 CI_IMAGE_BASE_NAME=${REGISTRY}/ci/mdbrain/${PROJECT_NAME}
 
 # parse all stages from multistage dockerfile
-targets_string=$(grep -oE ' AS .*| as .*' Dockerfile)
-targets=()
-while read -r line; do
-   targets+=("${line:3}")
-done <<< "$targets_string"
+targets=($(grep -ioP '^FROM [^\s]+ AS\K [^\s]+$' Dockerfile))
 
 function pull (){
     target=${1}


### PR DESCRIPTION
The regex ` AS .*| as .*` that finds stage names in `scripts/build_image_from_cache.sh` matched "as" in comment lines in my Dockerfile, which was an inconvience and took some unnecessary time to figure out. The new regex solves the problem with less lines of cryptic bash (albeit more cryptic regex) and is more specific, so it doesn't match comments.

Running
```bash
#! /bin/bash

parse() {
	targets_string=$(grep "$1" "$2" Dockerfile)
	echo "STRINGS"
	echo $targets_string

	targets=()
	while read -r line; do
	   targets+=("${line:3}")
	done <<< "$targets_string"

	echo "TARGETS"
	echo $targets
}

echo "OLD REGEX"
parse -oE ' AS .*| as .*'

echo
echo "NEW REGEX"
parse -ioP '^FROM [^\s]*\K AS .+$'

echo
echo "COMPACT"
targets=($(grep -ioP '^FROM [^\s]+ AS\K [^\s]+$' Dockerfile))
echo $targets

echo
echo "COMPACT LOOP"
for i in "$targets[@]"; do
	echo "${i}"
done
```
on
```Dockerfile
FROM base_images/md_base:0.1.4 AS uppercase
from base_images/md_base:0.1.4 as lowercase
FROM ubuntu as mixed

# define as variable on commandline not as global env var
# from malicous comments as test

# the AS clause is a reserved keyword in docker
# from malicous comments as test
```
results in
```
OLD REGEX
STRINGS
 AS uppercase
 as lowercase
 as mixed
 as variable on commandline not as global env var
 as test
 AS clause is a reserved keyword in docker
 as test
TARGETS
uppercase lowercase mixed variable on commandline not as global env var test clause is a reserved keyword in docker test

NEW REGEX
STRINGS
 AS uppercase
 as lowercase
 as mixed
TARGETS
uppercase lowercase mixed

COMPACT
uppercase lowercase mixed

COMPACT LOOP
uppercase
lowercase
mixed
```

which is the desired outcome. I've also tested it successfully on the problematic dockerfile